### PR TITLE
Copy plugin images to PluginDist

### DIFF
--- a/Plogon/BuildProcessor.cs
+++ b/Plogon/BuildProcessor.cs
@@ -520,6 +520,15 @@ public class BuildProcessor
                         file.CopyTo(Path.Combine(repoOutputDir.FullName, file.Name), true);
                     }
 
+                    var imagesSourcePath = Path.Combine(dpOutput.FullName, "images");
+                    if (Directory.Exists(imagesSourcePath)) 
+                    {
+                        var imagesDestinationPath = Path.Combine(repoOutputDir.FullName, "images");
+                        if (Directory.Exists(imagesDestinationPath))
+                            Directory.Delete(imagesDestinationPath, true);
+                        Directory.Move(imagesSourcePath, imagesDestinationPath);
+                    }
+
                     // DELETE THIS!!
                     var manifestFile = new FileInfo(Path.Combine(repoOutputDir.FullName, $"{task.InternalName}.json"));
                     var manifestText = await File.ReadAllTextAsync(manifestFile.FullName);

--- a/Plogon/BuildProcessor.cs
+++ b/Plogon/BuildProcessor.cs
@@ -520,7 +520,7 @@ public class BuildProcessor
                         file.CopyTo(Path.Combine(repoOutputDir.FullName, file.Name), true);
                     }
 
-                    var imagesSourcePath = Path.Combine(dpOutput.FullName, "images");
+                    var imagesSourcePath = Path.Combine(task.Manifest.Directory.FullName, "images");
                     if (Directory.Exists(imagesSourcePath)) 
                     {
                         var imagesDestinationPath = Path.Combine(repoOutputDir.FullName, "images");

--- a/Plogon/Manifests/Manifest.cs
+++ b/Plogon/Manifests/Manifest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Runtime.Serialization;
 #pragma warning disable CS1591
 #pragma warning disable CS8618
@@ -28,4 +29,6 @@ public class Manifest
     }
     
     public PluginInfo Plugin { get; set; }
+
+    public DirectoryInfo Directory { get; set; }
 }

--- a/Plogon/Manifests/ManifestStorage.cs
+++ b/Plogon/Manifests/ManifestStorage.cs
@@ -43,7 +43,9 @@ public class ManifestStorage
             try
             {
                 var tomlText = manifestDir.GetFiles("*.toml").First().OpenText().ReadToEnd();
-                manifests.Add(manifestDir.Name, Toml.ToModel<Manifest>(tomlText));
+                var manifest = Toml.ToModel<Manifest>(tomlText);
+                manifest.Directory = manifestDir;
+                manifests.Add(manifestDir.Name, manifest);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fixes #12 

I know there's a more sophisticated solution planned in https://github.com/goatcorp/DIPs/pull/45 however it seems like that won't be ready for 6.2 and as it stands all plugins updated to DP17 are completely without icons and images.