### PR TITLE
Allow running without specifying Discord webhook

### DIFF
--- a/Plogon/DiscordWebhook.cs
+++ b/Plogon/DiscordWebhook.cs
@@ -18,9 +18,9 @@ public class DiscordWebhook
     /// <summary>
     /// Init with webhook from env var
     /// </summary>
-    public DiscordWebhook()
+    public DiscordWebhook(string webhook)
     {
-        this.Client = new DiscordWebhookClient(Environment.GetEnvironmentVariable("DISCORD_WEBHOOK"));
+        this.Client = new DiscordWebhookClient(webhook);
     }
 
     private static DateTime GetPacificStandardTime()

--- a/Plogon/Program.cs
+++ b/Plogon/Program.cs
@@ -346,36 +346,32 @@ class Program
 
                             foreach (var id in msgIds)
                             {
-                                await webhook.Client.ModifyMessageAsync(ulong.Parse(id), properties =>
-                                {
-                                    var embed = properties.Embeds.Value.First();
-                                    var newEmbed = new EmbedBuilder()
-                                        .WithColor(Color.LightGrey)
-                                        .WithTitle(embed.Title)
-                                        .WithCurrentTimestamp()
-                                        .WithDescription(embed.Description);
+                                if (webhook is not null)
+                                    await webhook.Client.ModifyMessageAsync(ulong.Parse(id), properties => {
+                                        var embed = properties.Embeds.Value.First();
+                                        var newEmbed = new EmbedBuilder()
+                                            .WithColor(Color.LightGrey)
+                                            .WithTitle(embed.Title)
+                                            .WithCurrentTimestamp()
+                                            .WithDescription(embed.Description);
 
-                                    if (embed.Author.HasValue)
-                                        newEmbed = newEmbed.WithAuthor(embed.Author.Value.Name,
-                                            embed.Author.Value.IconUrl,
-                                            embed.Author.Value.Url);
+                                        if (embed.Author.HasValue)
+                                            newEmbed = newEmbed.WithAuthor(embed.Author.Value.Name,
+                                                embed.Author.Value.IconUrl,
+                                                embed.Author.Value.Url);
 
-                                    if (embed.Footer.HasValue)
-                                    {
-                                        if (embed.Footer.Value.Text.Contains("Comment"))
-                                        {
-                                            newEmbed = newEmbed.WithFooter(
-                                                embed.Footer.Value.Text.Replace("Comment", "Committed"),
-                                                embed.Footer.Value.IconUrl);
+                                        if (embed.Footer.HasValue) {
+                                            if (embed.Footer.Value.Text.Contains("Comment")) {
+                                                newEmbed = newEmbed.WithFooter(
+                                                    embed.Footer.Value.Text.Replace("Comment", "Committed"),
+                                                    embed.Footer.Value.IconUrl);
+                                            } else {
+                                                newEmbed = newEmbed.WithFooter("Committed");
+                                            }
                                         }
-                                        else
-                                        {
-                                            newEmbed = newEmbed.WithFooter("Committed");
-                                        }
-                                    }
 
-                                    properties.Embeds = new[] { newEmbed.Build() };
-                                });
+                                        properties.Embeds = new[] { newEmbed.Build() };
+                                    });
                             }
                         }
                         catch (Exception ex)


### PR DESCRIPTION
Running Plogon without setting the environment variable throws

```
Unhandled exception: System.ArgumentNullException: The given webhook Url cannot be null or whitespace. (Parameter 'webhookUrl')
   at Discord.Webhook.DiscordWebhookClient.ParseWebhookUrl(String webhookUrl, UInt64& webhookId, String& webhookToken)
   at Discord.Webhook.DiscordWebhookClient..ctor(String webhookUrl, DiscordRestConfig config)
   at Discord.Webhook.DiscordWebhookClient..ctor(String webhookUrl)
   at Plogon.DiscordWebhook..ctor() in D:\code\c#\ffxiv\Plogon\Plogon\DiscordWebhook.cs:line 23
```

This just makes it optional. ~~Also Plogon's code hasn't been ran under a formatter lol.~~