### PR TITLE
Add Development mode for easy local validation

### DIFF
--- a/Plogon/Program.cs
+++ b/Plogon/Program.cs
@@ -38,6 +38,11 @@ class Program
         /// We are running a continuous verification build for Dalamud.
         /// </summary>
         Continuous,
+
+        /// <summary>
+        /// We are building a plugin in dev mode to validate Plogon itself.
+        /// </summary>
+        Development,
     }
 
     /// <summary>
@@ -634,13 +639,13 @@ class Program
             Log.Error("Could not get PR for round robin assign");
             return;
         }
-        
+
         // Only go on if we don't have an assignee
         if (thisPr.Assignees.Any())
             return;
 
         string? loginToAssign;
-        
+
         // Find the last new plugin PR
         //var prs = await gitHubApi.Client.PullRequest.GetAllForRepository(gitHubApi.RepoOwner, gitHubApi.RepoName);
         var result = await gitHubApi.Client.Search.SearchIssues(
@@ -650,8 +655,8 @@ class Program
                           {
                               { gitHubApi.RepoOwner, gitHubApi.RepoName },
                           },
-                          Is = new [] { IssueIsQualifier.PullRequest },
-                          Labels = new []{ PlogonSystemDefine.PR_LABEL_NEW_PLUGIN },
+                          Is = new[] { IssueIsQualifier.PullRequest },
+                          Labels = new[] { PlogonSystemDefine.PR_LABEL_NEW_PLUGIN },
                           SortField = IssueSearchSort.Created,
                       });
         var lastNewPluginPr = result?.Items.FirstOrDefault(x => x.Number != prNumber);
@@ -678,7 +683,7 @@ class Program
                 }
             }
         }
-        
+
         await gitHubApi.Assign(prNumber, loginToAssign);
     }
 


### PR DESCRIPTION
Adds a `--mode=Development` for simpler local build debugging. All that needs to be done to test a build now is to set up a mock workspace with their own plugin's manifest, and then to run Plogon with `--build-all` against that:

![image](https://github.com/goatcorp/Plogon/assets/49822414/f6b104bb-e0d6-44c8-8a1d-6adcd9c5edc5)

```pwsh
dotnet run --project .\Plogon\Plogon.csproj -- --manifest-folder=./output/manifests --output-folder=./output/output --work-folder=./output/work --static-folder=./Plogon/static --artifact-folder=./output/artifacts --mode=Development --build-all
```
