### PR TITLE
Bump LibGit2Sharp to 0.30.0

### DIFF
--- a/Plogon/Plogon.csproj
+++ b/Plogon/Plogon.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
       <PackageReference Include="AWSSDK.S3" Version="3.7.305.24" />
       <PackageReference Include="Docker.DotNet" Version="3.125.5" />
-      <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0182" />
+      <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="Octokit" Version="10.0.0" />
       <PackageReference Include="PgpCore" Version="5.10.0" />


### PR DESCRIPTION
This version fixes loading SSL libraries on Fedora (and probably other modern distributions.)

Fixes the error `LibGit2Sharp.LibGit2SharpException: could not load ssl libraries`. Everything else seems to work and nothing else exceptional is listed in their changelog.