### PR TITLE
Add Image Size/Type Verification

### DIFF
--- a/Plogon/BuildProcessor.cs
+++ b/Plogon/BuildProcessor.cs
@@ -29,6 +29,8 @@ using Plogon.Repo;
 
 using Serilog;
 
+using SixLabors.ImageSharp;
+
 using Tag = Amazon.S3.Model.Tag;
 
 namespace Plogon;
@@ -1129,6 +1131,26 @@ public class BuildProcessor
         if (exitCode == 0 && !commit && File.Exists(Path.Combine(imagesSourcePath, "icon.png")) == false)
         {
             throw new MissingIconException();
+        } else
+        {
+            var imagePath = Path.Combine(Path.Combine(imagesSourcePath, "icon.png"));
+            // open the image and check if it's a valid PNG and has square dimensions
+            try
+            {
+                using var image = Image.Load(imagePath);
+                if (image.Metadata.DecodedImageFormat != SixLabors.ImageSharp.Formats.Png.PngFormat.Instance)
+                {
+                    throw new InvalidIconException("Icon is not a valid PNG file.", null);
+                }
+                if (image.Width != image.Height)
+                {
+                    throw new InvalidIconException("Icon must have square dimensions.", null);
+                }
+            } catch (Exception ex)
+            {
+                Log.Error(ex, "Icon validation failed");
+                throw new InvalidIconException("Icon validation failed", ex);
+            }
         }
 
         await this.dockerClient.Containers.RemoveContainerAsync(containerCreateResponse.ID,
@@ -1453,6 +1475,20 @@ public class BuildProcessor
         /// </summary>
         public MissingIconException()
             : base("Missing icon.")
+        {
+        }
+    }
+
+    /// <summary>
+    /// Exception if icon is invalid (not a PNG or not square)
+    /// </summary>
+    public class InvalidIconException : Exception
+    {
+        /// <summary>
+        /// ctor
+        /// </summary>
+        public InvalidIconException(string message, Exception? innerException)
+            : base("Invalid icon.", innerException)
         {
         }
     }

--- a/Plogon/BuildProcessor.cs
+++ b/Plogon/BuildProcessor.cs
@@ -1133,7 +1133,7 @@ public class BuildProcessor
             throw new MissingIconException();
         } else
         {
-            var imagePath = Path.Combine(Path.Combine(imagesSourcePath, "icon.png"));
+            var imagePath = Path.Combine(imagesSourcePath, "icon.png");
             // open the image and check if it's a valid PNG and has square dimensions
             try
             {
@@ -1141,6 +1141,14 @@ public class BuildProcessor
                 if (image.Metadata.DecodedImageFormat != SixLabors.ImageSharp.Formats.Png.PngFormat.Instance)
                 {
                     throw new InvalidIconException("Icon is not a valid PNG file.", null);
+                }
+                if (image.Width > 512 || image.Height > 512)
+                {
+                    throw new InvalidIconException("Icon dimensions must not exceed 512x512.", null);
+                }
+                if (image.Width < 64 || image.Height < 64)
+                {
+                    throw new InvalidIconException("Icon dimensions must be at least 64x64.", null);
                 }
                 if (image.Width != image.Height)
                 {

--- a/Plogon/BuildProcessor.cs
+++ b/Plogon/BuildProcessor.cs
@@ -1483,7 +1483,7 @@ public class BuildProcessor
         /// ctor
         /// </summary>
         public MissingIconException()
-            : base("Missing icon.")
+            : base("Missing file images/icon.png, an icon is required.")
         {
         }
     }

--- a/Plogon/BuildProcessor.cs
+++ b/Plogon/BuildProcessor.cs
@@ -1142,18 +1142,19 @@ public class BuildProcessor
                 {
                     throw new InvalidIconException("Icon is not a valid PNG file.", null);
                 }
-                if (image.Width > 512 || image.Height > 512)
-                {
-                    throw new InvalidIconException("Icon dimensions must not exceed 512x512.", null);
-                }
-                if (image.Width < 64 || image.Height < 64)
-                {
-                    throw new InvalidIconException("Icon dimensions must be at least 64x64.", null);
-                }
                 if (image.Width != image.Height)
                 {
                     throw new InvalidIconException("Icon must have square dimensions.", null);
                 }
+                if (image.Width > 512)
+                {
+                    throw new InvalidIconException("Icon dimensions must not exceed 512x512 and must be square.", null);
+                }
+                if (image.Width < 64)
+                {
+                    throw new InvalidIconException("Icon dimensions must be at least 64x64 and must be square.", null);
+                }
+                
             } catch (Exception ex)
             {
                 Log.Error(ex, "Icon validation failed");

--- a/Plogon/BuildProcessor.cs
+++ b/Plogon/BuildProcessor.cs
@@ -1130,7 +1130,7 @@ public class BuildProcessor
         var imagesSourcePath = Path.Combine(task.Manifest.File.Directory.FullName, "images");
         if (exitCode == 0 && !commit && File.Exists(Path.Combine(imagesSourcePath, "icon.png")) == false)
         {
-            throw new MissingIconException();
+            throw new MissingIconException("Missing file images/icon.png, an icon is required.");
         } else
         {
             var imagePath = Path.Combine(imagesSourcePath, "icon.png");
@@ -1140,25 +1140,25 @@ public class BuildProcessor
                 using var image = Image.Load(imagePath);
                 if (image.Metadata.DecodedImageFormat != SixLabors.ImageSharp.Formats.Png.PngFormat.Instance)
                 {
-                    throw new InvalidIconException("Icon is not a valid PNG file.", null);
+                    throw new MissingIconException("Icon is not a valid PNG file.");
                 }
                 if (image.Width != image.Height)
                 {
-                    throw new InvalidIconException("Icon must have square dimensions.", null);
+                    throw new MissingIconException("Icon must have square dimensions.");
                 }
                 if (image.Width > 512)
                 {
-                    throw new InvalidIconException("Icon dimensions must not exceed 512x512 and must be square.", null);
+                    throw new MissingIconException("Icon dimensions must not exceed 512x512 and must be square.");
                 }
                 if (image.Width < 64)
                 {
-                    throw new InvalidIconException("Icon dimensions must be at least 64x64 and must be square.", null);
+                    throw new MissingIconException("Icon dimensions must be at least 64x64 and must be square.");
                 }
                 
             } catch (Exception ex)
             {
                 Log.Error(ex, "Icon validation failed");
-                throw new InvalidIconException("Icon validation failed", ex);
+                throw new MissingIconException("Icon validation failed", ex);
             }
         }
 
@@ -1482,22 +1482,8 @@ public class BuildProcessor
         /// <summary>
         /// ctor
         /// </summary>
-        public MissingIconException()
-            : base("Missing file images/icon.png, an icon is required.")
-        {
-        }
-    }
-
-    /// <summary>
-    /// Exception if icon is invalid (not a PNG or not square)
-    /// </summary>
-    public class InvalidIconException : Exception
-    {
-        /// <summary>
-        /// ctor
-        /// </summary>
-        public InvalidIconException(string message, Exception? innerException)
-            : base("Invalid icon.", innerException)
+        public MissingIconException(string message, Exception? innerException = null)
+            : base(message, innerException)
         {
         }
     }

--- a/Plogon/Plogon.csproj
+++ b/Plogon/Plogon.csproj
@@ -16,6 +16,7 @@
       <PackageReference Include="PgpCore" Version="6.5.3" />
       <PackageReference Include="Serilog" Version="4.3.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+      <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
       <PackageReference Include="System.CommandLine.DragonFruit" Version="0.4.0-alpha.22114.1" />
       <PackageReference Include="Tomlyn" Version="0.19.0" />
     </ItemGroup>

--- a/Plogon/Program.cs
+++ b/Plogon/Program.cs
@@ -497,6 +497,15 @@ class Program
 
                         prLabels |= GitHubApi.PrLabel.NeedIcon;
                     }
+                    catch (BuildProcessor.InvalidIconException ex)
+                    {
+                        Log.Error(ex, "Invalid icon!");
+                        buildsMd.AddRow("🖼️", $"{task.InternalName} [{task.Channel}]", fancyCommit,
+                            $"Invalid icon in images/ build output! {ex.Message}");
+                        numFailed++;
+                        numNoIcon++;
+                        prLabels |= GitHubApi.PrLabel.NeedIcon;
+                    }
                     catch (BuildProcessor.ApiLevelException api)
                     {
                         Log.Error("Bad API level!");

--- a/Plogon/Program.cs
+++ b/Plogon/Program.cs
@@ -487,23 +487,14 @@ class Program
                         aborted = true;
                         numFailed++;
                     }
-                    catch (BuildProcessor.MissingIconException)
+                    catch (BuildProcessor.MissingIconException ex)
                     {
-                        Log.Error("Missing icon!");
+                        Log.Error(ex, "Missing or invalid icon!");
                         buildsMd.AddRow("🖼️", $"{task.InternalName} [{task.Channel}]", fancyCommit,
-                            "Missing icon in images/ build output!");
+                            $"Missing or invalid icon in images/ build output! {ex.Message}");
                         numFailed++;
                         numNoIcon++;
 
-                        prLabels |= GitHubApi.PrLabel.NeedIcon;
-                    }
-                    catch (BuildProcessor.InvalidIconException ex)
-                    {
-                        Log.Error(ex, "Invalid icon!");
-                        buildsMd.AddRow("🖼️", $"{task.InternalName} [{task.Channel}]", fancyCommit,
-                            $"Invalid icon in images/ build output! {ex.Message}");
-                        numFailed++;
-                        numNoIcon++;
                         prLabels |= GitHubApi.PrLabel.NeedIcon;
                     }
                     catch (BuildProcessor.ApiLevelException api)

--- a/Plogon/Program.cs
+++ b/Plogon/Program.cs
@@ -285,7 +285,7 @@ class Program
                         var relevantCommitHashForWebServices = task.Manifest.Plugin.Commit;
 
                         var manifestOwners = task.Manifest.Plugin.AllContributors.Union(PlogonSystemDefine.PacMembers);
-                        var isManifestOwner = manifestOwners.Any(x => x == githubActor);
+                        var isManifestOwner = manifestOwners.Any(x => x.Equals(githubActor, StringComparison.CurrentCultureIgnoreCase));
 
                         // Removals do not have a manifest, so we need to use the have commit (as that is what we are removing)
                         if (task.Type == BuildTask.TaskType.Remove)

--- a/Plogon/Program.cs
+++ b/Plogon/Program.cs
@@ -551,7 +551,7 @@ class Program
                         $"[Show log](https://github.com/goatcorp/DalamudPluginsD17/actions/runs/{actionRunId}) - [Review](https://github.com/goatcorp/DalamudPluginsD17/pull/{prNumber}/files#submit-review)";
 
                     var commentText = anyFailed ? "Builds failed, please check action output." : "All builds OK!";
-                    commentText += "\n\n**Take care!** Please test your plugins in-game before submitting them here to prevent crashes and instability. We really appreciate it!\n\n";
+                    commentText += "\n\n**Take care!** Please test your plugins in-game before submitting them here to prevent crashes and instability. We really appreciate it! By submitting a plugin, you agree to our [AI Usage Policy](https://github.com/goatcorp/governance/blob/main/ai-policy-official-repo.md).\n\n";
 
                     if (!anyTried)
                         commentText =


### PR DESCRIPTION
Makes Plogon check the image is an actual png and has square dimensions. I didn't add specific height/width limits but can certainly do so. Also fixed the case sensitivity issue mentioned in #77 while I was in there.