### PR TITLE
Fail build if stable plugin was to be removed

### DIFF
--- a/Plogon/BuildProcessor.cs
+++ b/Plogon/BuildProcessor.cs
@@ -919,6 +919,11 @@ public class BuildProcessor
             if (!commit)
                 throw new Exception("Can't remove plugins if not committing");
 
+            if (task.Channel == "stable")
+            {
+                throw new Exception("Refusing to remove stable plugin");
+            }
+
             this.pluginRepository.RemovePlugin(task.Channel, task.InternalName);
 
             var repoOutputDir = this.pluginRepository.GetPluginOutputDirectory(task.Channel, task.InternalName);
@@ -958,7 +963,7 @@ public class BuildProcessor
 
         if (task.Manifest.Plugin.ProjectPath.Contains(".."))
             throw new Exception("Not allowed");
-        
+
         // Always clone fresh
         if (workDir.Exists)
         {


### PR DESCRIPTION
Very simple check, if a plugin was to be removed we should not allow it to be removed from stable. If there's exceptions I can make it non-fatal and just warn in the comment.